### PR TITLE
Fix platform configs for a300

### DIFF
--- a/config/mrs_uav_system/a300.yaml
+++ b/config/mrs_uav_system/a300.yaml
@@ -8,8 +8,8 @@ uav_mass: 1.21 # overall mass of the drone
 # zero throttle thrist must correspond to min_rpm sqrt(0.460832101/0.000000045) = 3200,111459864
 motor_params:
   n_motors: 4
-  a: 0.2300
-  b: -0.0765
+  a: 0.2600
+  b: -0.1765
 
 # these model parameters can be used when
 # - 'attitude rate', and/or
@@ -22,7 +22,7 @@ model_params:
   propulsion:
     # force [N] = force_constant * rpm^2
     # for 21400 max rpm it is 20,475625 N then the force constant is 0.000000045
-    force_constant: 0.000000046626
+    force_constant: 0.000000045
 
     # torque [Nm] = torque_constant * force [N]
     torque_constant: 0.012 # 0.014 torque computed from power (efficiency estimated as 85% )
@@ -49,8 +49,8 @@ model_params:
     # inertia_matrix: []
 
     rpm:
-      min: 3103 # [revolutions/minute]
-      max: 20689 # [revolutions/minute]
+      min: 3200 # [revolutions/minute]
+      max: 21400 # [revolutions/minute]
 
 mrs_uav_managers:
   constraint_manager:

--- a/config/uavs/a300.yaml
+++ b/config/uavs/a300.yaml
@@ -10,10 +10,10 @@ a300:
   propulsion:
 
     # force [N] = force_constant * rpm^2
-    force_constant: 0.000000046626
+    force_constant: 0.000000045
 
     # moment [Nm] = moment_constant * force [N]
-    moment_constant: 0.012
+    moment_constant: 0.0012
 
     prop_radius: 0.089 # [m]
 
@@ -32,5 +32,5 @@ a300:
     ]
 
     rpm:
-      min: 3103 # [revolutions/minute]
-      max: 20689 # [revolutions/minute]
+      min: 3200 # [revolutions/minute]
+      max: 21400 # [revolutions/minute]


### PR DESCRIPTION
Change of the platform configs for platform a300 to maintain consistency with Gazebo simulation files located in alien_gazebo_resources and actual physical parameters of the platform.