### PR TITLE
Fix moment constant for a300 in multirotor simulator config

### DIFF
--- a/config/uavs/a300.yaml
+++ b/config/uavs/a300.yaml
@@ -13,7 +13,7 @@ a300:
     force_constant: 0.000000045
 
     # moment [Nm] = moment_constant * force [N]
-    moment_constant: 0.0012
+    moment_constant: 0.012
 
     prop_radius: 0.089 # [m]
 


### PR DESCRIPTION
The commit fixes the value of moment constant for a300 platform in multirotor simulator config.

This change should be replicated to ROS 2 branch. 