### PR TITLE
Add missing handling of heading exception in HW api plugin

### DIFF
--- a/src/hw_api_plugin.cpp
+++ b/src/hw_api_plugin.cpp
@@ -755,7 +755,12 @@ void Api::callbackOdom(const nav_msgs::Odometry::ConstPtr msg) {
 
   if (_capabilities_.produces_magnetometer_heading) {
 
-    double heading = mrs_lib::AttitudeConverter(odom->pose.pose.orientation).getHeading();
+    double heading = 0;
+    try {
+      heading = mrs_lib::AttitudeConverter(odom->pose.pose.orientation).getHeading();
+    } catch (mrs_lib::AttitudeConverter::GetHeadingException& e) { 
+      ROS_ERROR_THROTTLE(1.0, "[Api]: exception caught: '%s'", e.what());
+    }
 
     mrs_msgs::Float64Stamped hdg;
 


### PR DESCRIPTION
The commit adds try-catch around the call to mrs_lib::AttitudeConverter getHeading() function which can throw mrs_lib::AttitudeConverter::GetHeadingException. This exception was unhandled in hw_api_plugin so far. The error could be experienced only during an agile flight and even in that case it is rare. 