### PR TITLE
feat: Publish RC RSSI in HW api plugin

### DIFF
--- a/config/hw_api.yaml
+++ b/config/hw_api.yaml
@@ -32,6 +32,7 @@ plugin:
     altitude:             true
     magnetometer_heading: true
     rc_channels:          true
+    rc_rssi:              true
     battery_state:        true
     position:             true
     orientation:          true

--- a/src/hw_api_plugin.cpp
+++ b/src/hw_api_plugin.cpp
@@ -220,6 +220,7 @@ void Api::initialize(const rclcpp::Node::SharedPtr &node, std::shared_ptr<mrs_ua
   local_param_loader.loadParam("outputs/altitude", (bool &)_capabilities_.produces_altitude);
   local_param_loader.loadParam("outputs/magnetometer_heading", (bool &)_capabilities_.produces_magnetometer_heading);
   local_param_loader.loadParam("outputs/rc_channels", (bool &)_capabilities_.produces_rc_channels);
+  local_param_loader.loadParam("outputs/rc_rssi", (bool &)_capabilities_.produces_rc_rssi);
   local_param_loader.loadParam("outputs/battery_state", (bool &)_capabilities_.produces_battery_state);
   local_param_loader.loadParam("outputs/position", (bool &)_capabilities_.produces_position);
   local_param_loader.loadParam("outputs/orientation", (bool &)_capabilities_.produces_orientation);
@@ -934,6 +935,13 @@ void Api::publishRC(void) {
     rc.channels.push_back(0);
 
     common_handlers_->publishers.publishRcChannels(rc);
+  }
+
+  if (_capabilities_.produces_rc_rssi) {
+    mrs_msgs::msg::HwApiRcRssi rssi_out;
+    rssi_out.stamp = clock_->now(); 
+    rssi_out.rssi  = 0; 
+    common_handlers_->publishers.publishRcRssi(rssi_out);
   }
 }
 


### PR DESCRIPTION
## Summary
- **What changed**:
    - Publishing RC RSSI
    - Modified the hw api plugin config file to specify that it produces rc_rssi 
- **Why**:
    - Currently, `HwApi` only shares the **RC Channels**,  and not using the  **RC Received Signal Strength Indicator (RSSI)**  that PX4 already shares in the `rc` [message](https://github.com/mavlink/mavros/blob/master/mavros_msgs/msg/RCIn.msg#L4)

## Impact
- **Breaking changes**: 
     Depends on:
     `mrs_msgs`:  https://github.com/ctu-mrs/mrs_msgs/pull/23
     `hw_api`: https://github.com/ctu-mrs/mrs_uav_hw_api/pull/7

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [x] Tested on real HW