### PR TITLE
feat: use static_tf_publisher for static garmin tf

### DIFF
--- a/include/mrs_multirotor_simulator/uav_system_ros.h
+++ b/include/mrs_multirotor_simulator/uav_system_ros.h
@@ -4,6 +4,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <mrs_lib/transform_broadcaster.h>
+#include <tf2_ros/static_transform_broadcaster.h>
 
 #include <mrs_lib/param_loader.h>
 #include <mrs_lib/publisher_handler.h>
@@ -115,7 +116,10 @@ private:
 
   // | --------------------------- tf --------------------------- |
 
-  std::shared_ptr<mrs_lib::TransformBroadcaster> tf_broadcaster_;
+  std::shared_ptr<mrs_lib::TransformBroadcaster>       tf_broadcaster_;
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
+
+  void publishRangefinderStaticTF(void);
 
   // | ----------------------- subscribers ---------------------- |
 

--- a/src/uav_system_ros.cpp
+++ b/src/uav_system_ros.cpp
@@ -286,6 +286,11 @@ UavSystemRos::UavSystemRos(const UavSystemRos_CommonHandlers_t common_handlers) 
     tf_broadcaster_ = std::make_shared<mrs_lib::TransformBroadcaster>(node_);
   }
 
+  if (_publish_rangefinder_tf_) {
+    static_tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node_);
+    publishRangefinderStaticTF();
+  }
+
   // | --------------------- service servers -------------------- |
 
   ss_set_mass_ = mrs_lib::ServiceServerHandler<mrs_msgs::srv::Float64Srv>(
@@ -518,8 +523,6 @@ void UavSystemRos::publishRangefinder(const MultirotorModel::State &state) {
     return;
   }
 
-  // | ----------------------- publish tf ----------------------- |
-
   const Eigen::Vector3d body_z          = state.R.col(2);
   const Eigen::Vector3d rangefinder_dir = -body_z;
 
@@ -549,23 +552,27 @@ void UavSystemRos::publishRangefinder(const MultirotorModel::State &state) {
   range.field_of_view   = 0.01;
 
   ph_rangefinder_->publish(range);
+}
 
-  if (_publish_rangefinder_tf_) {
+//}
 
-    geometry_msgs::msg::TransformStamped tf;
+/* publishRangefinderStaticTF() //{ */
 
-    tf.header.stamp    = time_stamp_;
-    tf.header.frame_id = _frame_fcu_;
-    tf.child_frame_id  = _frame_rangefinder_;
+void UavSystemRos::publishRangefinderStaticTF(void) {
 
-    tf.transform.translation.x = 0;
-    tf.transform.translation.y = 0;
-    tf.transform.translation.z = -0.05;
+  geometry_msgs::msg::TransformStamped tf;
 
-    tf.transform.rotation = mrs_lib::AttitudeConverter(0, 1.57, 0);
+  tf.header.stamp    = node_->get_clock()->now();
+  tf.header.frame_id = _frame_fcu_;
+  tf.child_frame_id  = _frame_rangefinder_;
 
-    tf_broadcaster_->sendTransform(tf);
-  }
+  tf.transform.translation.x = 0;
+  tf.transform.translation.y = 0;
+  tf.transform.translation.z = -0.05;
+
+  tf.transform.rotation = mrs_lib::AttitudeConverter(0, 1.57, 0);
+
+  static_tf_broadcaster_->sendTransform(tf);
 }
 
 //}


### PR DESCRIPTION
## Summary
- **What changed**: 
The `fcu -> rangefinder` transform in `UavSystemRos` is now published once via `tf2_ros::StaticTransformBroadcaster` on `/tf_static` (in the constructor, gated by the existing `frames/rangefinder/publish_tf` param) instead of being re-sent every simulation step through the dynamic `mrs_lib::TransformBroadcaster` on `/tf`.
- **Why**: 
This transform is a fixed body-frame offset that never changes at runtime, so re-publishing it on every simulation tick was redundant.  See #11 
- **Notes for reviewers**: 

## Impact
- **Affected areas**: 
`mrs_multirotor_simulator` TF publishing for the simulated rangefinder frame. No topic, message, or service API changes.
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
 ```bash
 colcon build --packages-select mrs_multirotor_simulator
 ros2 launch mrs_multirotor_simulator multirotor_simulator.launch.py

 # confirm the fcu->rangefinder transform is now published on /tf_static, once, and no longer on /tf
 ros2 topic echo /tf_static