### PR TITLE
Fix uninitialized warning

### DIFF
--- a/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/multirotor_model.hpp
+++ b/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/multirotor_model.hpp
@@ -224,7 +224,7 @@ inline void MultirotorModel::step(const double& dt) {
 
   boost::numeric::odeint::runge_kutta4<InternalState> rk;
 
-  odeint::integrate_n_steps(rk, boost::ref(*this), internal_state_, 0.0, dt, 1);
+  odeint::integrate_n_steps(std::ref(rk), std::ref(*this), internal_state_, 0.0, dt, 1);
 
   for (int i = 0; i < N_INTERNAL_STATES; ++i) {
     if (std::isnan(internal_state_.at(i))) {


### PR DESCRIPTION
When compiling mrs_multirotor_simulator with warnings and on `-O2`/`-O3`, there is a `-Wuninitialized` warning from `MultirotorModel::step`. I've traced it to an uninitialized fields inside the `runge_kutta4` structure from boost (it looks like they are initialized later when running the algorithm), which results in uninitialized read when passing it by value to `integrate_n_steps`. To mitigate this warning, we can instead pass by reference, which does not read the uninitalized fields.

<details>

<summary>Full warning message</summary>

```
In file included from /usr/include/boost/numeric/odeint/stepper/runge_kutta4.hpp:27,
                 from /usr/include/boost/numeric/odeint.hpp:29,
                 from [...]/extern/mrs_multirotor_simulator/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/multirotor_model.hpp:13,
                 from [...]/extern/mrs_multirotor_simulator/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/uav_system.hpp:6,
                 from [...]/src/optional_features/multirotor_simulator_support/multirotor_agent.cpp:4:
In copy constructor ‘constexpr boost::numeric::odeint::explicit_generic_rk<4, 4, boost::array<double, 18>, double, boost::array<double, 18>, double, boost::numeric::odeint::array_algebra, boost::numeric::odeint::default_operations, boost::numeric::odeint::initially_resizer>::explicit_generic_rk(const boost::numeric::odeint::explicit_generic_rk<4, 4, boost::array<double, 18>, double, boost::array<double, 18>, double, boost::numeric::odeint::array_algebra, boost::numeric::odeint::default_operations, boost::numeric::odeint::initially_resizer>&)’,
    inlined from ‘constexpr boost::numeric::odeint::runge_kutta4<boost::array<double, 18> >::runge_kutta4(const boost::numeric::odeint::runge_kutta4<boost::array<double, 18> >&)’ at /usr/include/boost/numeric/odeint/stepper/runge_kutta4.hpp:112:7,
    inlined from ‘void mrs_multirotor_simulator::MultirotorModel::step(const double&)’ at [...]/extern/mrs_multirotor_simulator/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/multirotor_model.hpp:227:28:
/usr/include/boost/numeric/odeint/stepper/explicit_generic_rk.hpp:94:7: warning: ‘rk.boost::numeric::odeint::runge_kutta4<boost::array<double, 18>, double, boost::array<double, 18>, double, boost::numeric::odeint::array_algebra, boost::numeric::odeint::default_operations, boost::numeric::odeint::initially_resizer>::<unnamed>.boost::numeric::odeint::explicit_generic_rk<4, 4, boost::array<double, 18>, double, boost::array<double, 18>, double, boost::numeric::odeint::array_algebra, boost::numeric::odeint::default_operations, boost::numeric::odeint::initially_resizer>::m_x_tmp’ is used uninitialized [-Wuninitialized]
   94 | class explicit_generic_rk : public explicit_stepper_base<
      |       ^~~~~~~~~~~~~~~~~~~
[...]/extern/mrs_multirotor_simulator/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/multirotor_model.hpp: In member function ‘void mrs_multirotor_simulator::MultirotorModel::step(const double&)’:
[...]/extern/mrs_multirotor_simulator/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/multirotor_model.hpp:225:55: note: ‘rk’ declared here
  225 |   boost::numeric::odeint::runge_kutta4<InternalState> rk;
      |                                                       ^~
In copy constructor ‘constexpr boost::numeric::odeint::explicit_generic_rk<4, 4, boost::array<double, 18>, double, boost::array<double, 18>, double, boost::numeric::odeint::array_algebra, boost::numeric::odeint::default_operations, boost::numeric::odeint::initially_resizer>::explicit_generic_rk(const boost::numeric::odeint::explicit_generic_rk<4, 4, boost::array<double, 18>, double, boost::array<double, 18>, double, boost::numeric::odeint::array_algebra, boost::numeric::odeint::default_operations, boost::numeric::odeint::initially_resizer>&)’,
    inlined from ‘constexpr boost::numeric::odeint::runge_kutta4<boost::array<double, 18> >::runge_kutta4(const boost::numeric::odeint::runge_kutta4<boost::array<double, 18> >&)’ at /usr/include/boost/numeric/odeint/stepper/runge_kutta4.hpp:112:7,
    inlined from ‘void mrs_multirotor_simulator::MultirotorModel::step(const double&)’ at [...]/extern/mrs_multirotor_simulator/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/multirotor_model.hpp:227:28:
/usr/include/boost/numeric/odeint/stepper/explicit_generic_rk.hpp:94:7: warning: ‘rk.boost::numeric::odeint::runge_kutta4<boost::array<double, 18>, double, boost::array<double, 18>, double, boost::numeric::odeint::array_algebra, boost::numeric::odeint::default_operations, boost::numeric::odeint::initially_resizer>::<unnamed>.boost::numeric::odeint::explicit_generic_rk<4, 4, boost::array<double, 18>, double, boost::array<double, 18>, double, boost::numeric::odeint::array_algebra, boost::numeric::odeint::default_operations, boost::numeric::odeint::initially_resizer>::m_F’ is used uninitialized [-Wuninitialized]
   94 | class explicit_generic_rk : public explicit_stepper_base<
      |       ^~~~~~~~~~~~~~~~~~~
[...]/extern/mrs_multirotor_simulator/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/multirotor_model.hpp: In member function ‘void mrs_multirotor_simulator::MultirotorModel::step(const double&)’:
[...]/extern/mrs_multirotor_simulator/mrs_multirotor_simulator_core/include/mrs_multirotor_simulator/uav_system/multirotor_model.hpp:225:55: note: ‘rk’ declared here
  225 |   boost::numeric::odeint::runge_kutta4<InternalState> rk;
      |                                                       ^~
```

</details>