### PR TITLE
feat: add simulated magnetic_field msg

### DIFF
--- a/mrs_multirotor_simulator/config/hw_api.yaml
+++ b/mrs_multirotor_simulator/config/hw_api.yaml
@@ -31,6 +31,7 @@ plugin:
     imu:                  true
     altitude:             true
     magnetometer_heading: true
+    magnetic_field:       true
     rc_channels:          true
     rc_rssi:              true
     battery_state:        true

--- a/mrs_multirotor_simulator/src/hw_api_plugin.cpp
+++ b/mrs_multirotor_simulator/src/hw_api_plugin.cpp
@@ -141,7 +141,7 @@ private:
   // | ------------------------- methods ------------------------ |
 
   void publishBatteryState(void);
-
+  void publishMagneticField(void);
   void publishRC(void);
 
   void timeoutInputs(void);
@@ -234,8 +234,7 @@ void Api::initialize(const rclcpp::Node::SharedPtr &node, std::shared_ptr<mrs_ua
   local_param_loader.loadParam("outputs/angular_velocity", (bool &)_capabilities_.produces_angular_velocity);
   local_param_loader.loadParam("outputs/odometry", (bool &)_capabilities_.produces_odometry);
   local_param_loader.loadParam("outputs/ground_truth", (bool &)_capabilities_.produces_ground_truth);
-
-  _capabilities_.produces_magnetic_field = false;
+  local_param_loader.loadParam("outputs/magnetic_field", (bool &)_capabilities_.produces_magnetic_field);
 
   if (!local_param_loader.loadedSuccessfully()) {
     RCLCPP_ERROR(node_->get_logger(), "Could not load all parameters!");
@@ -896,6 +895,8 @@ void Api::timerMain() {
 
   publishRC();
 
+  publishMagneticField();
+
   timeoutInputs();
 }
 
@@ -917,6 +918,30 @@ void Api::publishBatteryState(void) {
     msg.charge   = 0.8;
 
     common_handlers_->publishers.publishBatteryState(msg);
+  }
+}
+
+//}
+
+/* publishMagneticField() //{ */
+
+void Api::publishMagneticField(void) {
+
+  if (_capabilities_.produces_magnetic_field) {
+
+    sensor_msgs::msg::MagneticField magnetic_field;
+
+    magnetic_field.header.stamp    = node_->get_clock()->now();
+    magnetic_field.header.frame_id = _uav_name_ + "/" + _body_frame_name_;
+
+    // roughly the Earth's magnetic field in central Europe [T]
+    magnetic_field.magnetic_field.x = 2.1e-5;
+    magnetic_field.magnetic_field.y = 0.1e-5;
+    magnetic_field.magnetic_field.z = 4.3e-5;
+
+    magnetic_field.magnetic_field_covariance = {1e-12, 0.0, 0.0, 0.0, 1e-12, 0.0, 0.0, 0.0, 1e-12};
+
+    common_handlers_->publishers.publishMagneticField(magnetic_field);
   }
 }
 
@@ -946,8 +971,8 @@ void Api::publishRC(void) {
 
   if (_capabilities_.produces_rc_rssi) {
     mrs_msgs::msg::HwApiRcRssi rssi_out;
-    rssi_out.stamp = clock_->now(); 
-    rssi_out.rssi  = 0; 
+    rssi_out.stamp = clock_->now();
+    rssi_out.rssi  = 0;
     common_handlers_->publishers.publishRcRssi(rssi_out);
   }
 }


### PR DESCRIPTION
## Summary
- **What changed**:
`Api` (`mrs_multirotor_simulator/src/hw_api_plugin.cpp`) now implements the `magnetic_field` HW API output. Adds `Api::publishMagneticField()`, which publishes a `sensor_msgs::msg::MagneticField` (a fixed vector approximating Earth's magnetic field in central Europe, `{2.1e-5, 0.1e-5, 4.3e-5} T`, with a small fixed diagonal covariance) on the UAV's body frame, called from `timerMain()` right after `publishRC()`. `_capabilities_.produces_magnetic_field` is no longer hardcoded to `false` — it's now loaded from the new `outputs/magnetic_field` param (`mrs_multirotor_simulator/config/hw_api.yaml`), defaulted to `true`, following the same enable/disable pattern as the other HW API outputs (IMU, altitude, magnetometer heading, etc.).
- **Why**:
The simulator previously never produced a `magnetic_field` output, so any part of the MRS stack relying on `mrs_uav_hw_api`'s magnetic field capability had no simulated data source to run against.
- **Notes for reviewers**:
The published field is a static/constant vector (not derived from UAV attitude or position), so it's a simple presence signal for the capability rather than a physically-accurate simulated magnetometer.

## Impact
- **Affected areas**:
  - HW API plugin: `mrs_multirotor_simulator/src/hw_api_plugin.cpp` (`Api::publishMagneticField`, capability loading, `timerMain`)
  - Config: `mrs_multirotor_simulator/config/hw_api.yaml` (new `outputs/magnetic_field` flag)
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
```bash
colcon build --packages-select mrs_multirotor_simulator
# then run a sim session and check the magnetic field topic is published, e.g.:
ros2 launch mrs_multirotor_simulator hw_api.launch.py
ros2 topic echo /uav1/hw_api/magnetic_field