### PR TITLE
feat: publish simulated GNSS status and position covariance

### DIFF
--- a/mrs_multirotor_simulator/src/hw_api_plugin.cpp
+++ b/mrs_multirotor_simulator/src/hw_api_plugin.cpp
@@ -783,7 +783,31 @@ void Api::callbackOdom(const nav_msgs::msg::Odometry::ConstSharedPtr msg) {
     gnss.longitude = lon;
     gnss.altitude  = odom->pose.pose.position.z + _amsl_;
 
+    gnss.position_covariance[0] = 0.5;  // east variance [m^2]
+    gnss.position_covariance[4] = 0.5;  // north variance [m^2]
+    gnss.position_covariance[8] = 1.5;  // up variance [m^2]
+
+    gnss.position_covariance_type = sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+
     common_handlers_->publishers.publishGNSS(gnss);
+  }
+
+  // | ------------------- publish gnss status ------------------ |
+
+  if (_capabilities_.produces_gnss) {
+
+    mrs_msgs::msg::GpsInfo gnss_status;
+
+    gnss_status.stamp = odom->header.stamp;
+
+    gnss_status.fix_type = mrs_msgs::msg::GpsInfo::GPS_FIX_TYPE_3D_FIX;
+
+    gnss_status.satellites_visible = 12;
+
+    gnss_status.h_acc = 0.5;
+    gnss_status.v_acc = 0.8;
+
+    common_handlers_->publishers.publishGNSSStatus(gnss_status);
   }
 
   // | ----------------------- publish rtk ---------------------- |


### PR DESCRIPTION
## Summary
- **What changed**:
    In `hw_api_plugin.cpp`'s `callbackOdom()`, the existing `~/gnss` (`sensor_msgs/NavSatFix`) publish, gated on `_capabilities_.produces_gnss`, now also fills `position_covariance` (diagonal ENU variances: 0.5/0.5/1.5 m²) and `position_covariance_type = COVARIANCE_TYPE_DIAGONAL_KNOWN`. A new block, gated the same way, publishes `mrs_msgs::msg::GpsInfo` on `~/gnss_status` via `common_handlers_->publishers.publishGNSSStatus(...)`, with `fix_type = GPS_FIX_TYPE_3D_FIX`, `satellites_visible = 12`, `h_acc = 0.5`, `v_acc = 0.8`.
- **Why**:
    `mrs_uav_diagnostics_sensors`' `GNSSSensorHandler::fill_details()` reads `position_covariance` (for its `quality`/`uncertainty` details) and `GpsInfo.fix_type`/`satellites_visible`/`h_acc`/`v_acc` (for `fix_type`/`num_satellites`/`position_accuracy`) from these two topics. Without them, the simulator previously reported GNSS as `nan`/unknown in `mrs_uav_status`, even though the simulated GNSS fix was otherwise valid. The chosen covariance values keep the derived quality metric in the "good fix" (green, `<5.0`) band used by `mrs_uav_status`'s TUI coloring.
- **Notes for reviewers**:
    Values are simulated placeholders, not modeled from any real receiver noise profile — picked to look plausible and to exercise the green/yellow/red thresholds in `mrs_uav_status` sensibly. See `mrs_uav_diagnostics_sensors/src/gnss_handler.cpp`'s `fill_details()` for the exact downstream field consumption these values were matched against.

## Impact
- **Affected areas**: `mrs_uav_simulator_hw_api_plugin::Api::callbackOdom` (`mrs_multirotor_simulator/src/hw_api_plugin.cpp`)
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
```bash
colcon build --packages-select mrs_multirotor_simulator
bash mrs_multirotor_simulator/tmux/mrs_one_drone/start.sh
# in another terminal, with the sim + hw_api plugin running:
ros2 topic echo /uav1/hw_api/gnss --once
ros2 topic echo /uav1/hw_api/gnss_status --once